### PR TITLE
Add hotlink to mongrel2 icon on wikipedia

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -137,3 +137,7 @@ image = "https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/bitcoin.svg"
 [[params.usedby]]
 name = "Jupyter"
 image = "https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/jupyter.svg"
+
+[[params.usedby]]
+name = "Mongrel2"
+image = "https://upload.wikimedia.org/wikipedia/en/0/0b/Mongrel_2_logo.png"


### PR DESCRIPTION
Hotlink should be okay according to https://commons.wikimedia.org/wiki/Commons:Reusing_content_outside_Wikimedia