### PR TITLE
Problem: Content has link to Low-level API twice

### DIFF
--- a/content/docs/api.md
+++ b/content/docs/api.md
@@ -1,6 +1,0 @@
----
-title: Low-level API
-description: ZeroMQ API
-weight: 4
-url: "/api"
----


### PR DESCRIPTION
Solution: Remove the old link from Getting started section