### PR TITLE
Problem: Duplicate title for language pages

### DIFF
--- a/content/languages/c.md
+++ b/content/languages/c.md
@@ -3,8 +3,6 @@ title: C
 weight: 1
 ---
 
-# C
-
 Two options are available for C developers, CZMQ or libzmq, the low-level zeromq library.
 
 The recommended binding for C developers is CZMQ, which provides a high-level API for ØMQ, with additional classes such as pollers, thread management, and security helpers.

--- a/content/languages/cplusplus.md
+++ b/content/languages/cplusplus.md
@@ -3,8 +3,6 @@ title: C++
 weight: 2
 ---
 
-# C++
-
 ## cppzmq
 
 <table>
@@ -28,7 +26,7 @@ int main()
 }
 ```
 
-## zmqpp 
+## zmqpp
 
 <table>
 <tr><td>Github</td><td>https://github.com/zeromq/zmqpp</td></tr>

--- a/content/languages/csharp.md
+++ b/content/languages/csharp.md
@@ -3,8 +3,6 @@ title: C#
 weight: 3
 ---
 
-# C\#
-
 Two options are available for C# developers, [NetMQ](https://github.com/zeromq/netmq), a port of zeromq to C#, or [clrzmq4](https://github.com/zeromq/clrzmq4), C# binding for libzmq.
 
 NetMQ is the recommended option. However NetMQ doesn't implement ZMTP 3 and curve encryption at the moment.

--- a/content/languages/erlang.md
+++ b/content/languages/erlang.md
@@ -3,8 +3,6 @@ title: Erlang
 weight: 6
 ---
 
-# Erlang
-
 ## Chumak
 
 <table>

--- a/content/languages/fsharp.md
+++ b/content/languages/fsharp.md
@@ -3,8 +3,6 @@ title: F#
 weight: 5
 ---
 
-# F\#
-
 Two alternatives are available for F# developers, `fszmq` and `FsNetMQ`. `fszmq` is a binding over libzmq and FsNetMQ is a thin F# wrapper over NetMQ, which is a pure port of libzmq to C#.
 
 

--- a/content/languages/go.md
+++ b/content/languages/go.md
@@ -3,8 +3,6 @@ title: Go
 weight: 4
 ---
 
-# Go
-
 Two options are available for Go developers, [goczmq](https://github.com/zeromq/goczmq) binding for CZMQ, or [pebbe/zmq4](https://github.com/pebbe/zmq4), binding for libzmq.
 
 ## goczmq

--- a/content/languages/haskell.md
+++ b/content/languages/haskell.md
@@ -3,8 +3,6 @@ title: Haskell
 weight: 5
 ---
 
-# Haskell
-
 <table>
 <tr><td>Gitlab</td><td>https://gitlab.com/twittner/zeromq-haskell</td></tr>
 <tr><td>Hackage</td><td>http://hackage.haskell.org/package/zeromq4-haskell</td></tr>

--- a/content/languages/java.md
+++ b/content/languages/java.md
@@ -3,8 +3,6 @@ title: Java
 weight: 3
 ---
 
-# Java
-
 Three options are available for Java developers, JeroMQ a pure Java
 implementation, JZMQ a Java binding for libzmq, JCZMQ a Java binding for czmq
 

--- a/content/languages/nodejs.md
+++ b/content/languages/nodejs.md
@@ -3,8 +3,6 @@ title: NodeJS
 weight: 4
 ---
 
-# NodeJS
-
 <table>
 <tr><td>Github</td><td>https://github.com/zeromq/zeromq.js/</td></tr>
 <tr><td>npm</td><td>https://www.npmjs.com/package/zeromq</td></tr>

--- a/content/languages/perl.md
+++ b/content/languages/perl.md
@@ -3,8 +3,6 @@ title: Perl
 weight: 4
 ---
 
-# Perl
-
 <table>
 <tr><td>Github</td><td>https://github.com/zeromq/perlzmq</td></tr>
 <tr><td>cpan</td><td>https://metacpan.org/pod/ZMQ::FFI</td></tr>

--- a/content/languages/python.md
+++ b/content/languages/python.md
@@ -3,8 +3,6 @@ title: Python
 weight: 3
 ---
 
-# Python
-
 ## Pyzmq
 
 <table>

--- a/content/languages/ruby.md
+++ b/content/languages/ruby.md
@@ -3,8 +3,6 @@ title: Ruby
 weight: 3
 ---
 
-# Ruby
-
 <table>
 <tr><td>Github</td><td>https://github.com/zeromq/rbzmq</td></tr>
 <tr><td>gem</td><td>https://rubygems.org/gems/zmq</td></tr>

--- a/content/languages/rust.md
+++ b/content/languages/rust.md
@@ -3,8 +3,6 @@ title: Rust
 weight: 4
 ---
 
-# Rust
-
 <table>
 <tr><td>Github</td><td>https://github.com/erickt/rust-zmq</td></tr>
 <tr><td>Crate</td><td>https://docs.rs/crate/zmq</td></tr>


### PR DESCRIPTION
Solution: Remove the markdown headers because headers are set through
the title attribute in the frontmatter