### PR TITLE
Problem: Language/Lib select boxes are broken into two rows

### DIFF
--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -53,7 +53,7 @@
     <section class="section">
 
       {{ if (findRE "<div class=\"example-" .Content 1) }}
-      <div id="lang-lib-selector" class="columns">
+      <div id="lang-lib-selector" class="columns is-mobile">
       {{ with .Site.Params.examples }}
         <div class="field lang-selector" style="margin-right: 1em">
           <div class="control has-icons-left">


### PR DESCRIPTION
Solution: Ensure they stay on the same row by adding the is-mobile
class