### PR TITLE
nodejs: Use zeromq@5 branch

### DIFF
--- a/content/languages/nodejs.md
+++ b/content/languages/nodejs.md
@@ -10,10 +10,10 @@ weight: 4
 
 ## Installation
 
-To install ZeroMQ for Node, download and install the package from npm.
+To install ZeroMQ for Node, download and install the package from npm. Here we use the version 5.x branch since version 6.x is still in beta.
 
 ```
-$ npm install zeromq
+$ npm install zeromq@5
 ```
 
 ## Examples using zeromq


### PR DESCRIPTION
The current latest version of `zeromq` ([6.0.0-beta.6](https://www.npmjs.com/package/zeromq/v/6.0.0-beta.6) by the time of writing) [has no support](https://github.com/zeromq/zeromq.js/blob/v6.0.0-beta.6/src/compat.ts#L423-L436) for `bindSync`. To make the documentation working, we may ask users to use versio 5 branch for now.