### PR TITLE
Problem: zmqpp examples are shown in sidebar

### DIFF
--- a/content/docs/examples/cpp/zmqpp/index.md
+++ b/content/docs/examples/cpp/zmqpp/index.md
@@ -1,0 +1,3 @@
+---
+headless: true
+---


### PR DESCRIPTION
Solution: Make examples headless by adding an index.md