### PR TITLE
Problem: no "Hello world" example for Rust

### DIFF
--- a/content/docs/examples/rust/rust-zmq/hello_world_client.md
+++ b/content/docs/examples/rust/rust-zmq/hello_world_client.md
@@ -1,0 +1,30 @@
+---
+name: hello_world_client
+language: Rust
+library: rust-zmq
+---
+
+```rust
+#![crate_name = "helloworld_client"]
+
+//! Hello World client
+
+fn main() {
+    println!("Connecting to hello world server...\n");
+
+    let context = zmq::Context::new();
+    let requester = context.socket(zmq::REQ).unwrap();
+
+    assert!(requester.connect("tcp://localhost:5555").is_ok());
+
+    let mut msg = zmq::Message::new();
+
+    for request_nbr in 0..10 {
+        println!("Sending Hello {}...", request_nbr);
+        requester.send("Hello", 0).unwrap();
+
+        requester.recv(&mut msg, 0).unwrap();
+        println!("Received World {}: {}", msg.as_str().unwrap(), request_nbr);
+    }
+}
+```

--- a/content/docs/examples/rust/rust-zmq/hello_world_server.md
+++ b/content/docs/examples/rust/rust-zmq/hello_world_server.md
@@ -1,0 +1,31 @@
+---
+name: hello_world_server
+language: Rust
+library: rust-zmq
+---
+
+```rust
+#![crate_name = "helloworld_server"]
+
+//! Hello World server in Rust
+//! Binds REP socket to tcp://*:5555
+//! Expects "Hello" from client, replies with "World"
+
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    let context = zmq::Context::new();
+    let responder = context.socket(zmq::REP).unwrap();
+
+    assert!(responder.bind("tcp://*:5555").is_ok());
+
+    let mut msg = zmq::Message::new();
+    loop {
+        responder.recv(&mut msg, 0).unwrap();
+        println!("Received {}", msg.as_str().unwrap());
+        thread::sleep(Duration::from_millis(1000));
+        responder.send("World", 0).unwrap();
+    }
+}
+```


### PR DESCRIPTION
Solution: copy the examples from [rust-zmq repository](https://github.com/erickt/rust-zmq/tree/master/examples/zguide).