### PR TITLE
Problem: rust-zmq/index.md is missing

### DIFF
--- a/content/docs/examples/rust/rust-zmq/index.md
+++ b/content/docs/examples/rust/rust-zmq/index.md
@@ -1,0 +1,3 @@
+---
+headless: true
+---


### PR DESCRIPTION
Solution: add the file.