### PR TITLE
Problem: zeromq.org doesn't refer to our free hosting service

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,5 +5,8 @@
     <p class="has-text-weight-light">
       &copy; {{ $year }} The {{ $title }} authors
     </p>
+    <a style="font-size: 12px" href="https://www.netlify.com">
+      This site is powered by Netlify
+    </a>
   </div>
 </footer>


### PR DESCRIPTION
Solution: Add a link in the footer, that this site is powered by Netlify