### PR TITLE
Update NetMQ with curves

### DIFF
--- a/content/languages/csharp.md
+++ b/content/languages/csharp.md
@@ -5,7 +5,7 @@ weight: 3
 
 Two options are available for C# developers, [NetMQ](https://github.com/zeromq/netmq), a port of zeromq to C#, or [clrzmq4](https://github.com/zeromq/clrzmq4), C# binding for libzmq.
 
-NetMQ is the recommended option. NetMQ has implemented curve encryption. However NetMQ doesn't implement ZMTP 3 and curve encryption at the moment.
+NetMQ is the recommended option, which has implemented curve encryption.
 
 ## NetMQ
 

--- a/content/languages/csharp.md
+++ b/content/languages/csharp.md
@@ -5,7 +5,7 @@ weight: 3
 
 Two options are available for C# developers, [NetMQ](https://github.com/zeromq/netmq), a port of zeromq to C#, or [clrzmq4](https://github.com/zeromq/clrzmq4), C# binding for libzmq.
 
-NetMQ is the recommended option, which has implemented curve encryption.
+NetMQ is the recommended option, which has implemented curve encryption (https://github.com/zeromq/netmq/blob/master/src/NetMQ.Tests/CurveTests.cs).
 
 ## NetMQ
 

--- a/content/languages/csharp.md
+++ b/content/languages/csharp.md
@@ -5,7 +5,7 @@ weight: 3
 
 Two options are available for C# developers, [NetMQ](https://github.com/zeromq/netmq), a port of zeromq to C#, or [clrzmq4](https://github.com/zeromq/clrzmq4), C# binding for libzmq.
 
-NetMQ is the recommended option. However NetMQ doesn't implement ZMTP 3 and curve encryption at the moment.
+NetMQ is the recommended option. NetMQ has implemented curve encryption. However NetMQ doesn't implement ZMTP 3 and curve encryption at the moment.
 
 ## NetMQ
 


### PR DESCRIPTION
According to this (https://github.com/zeromq/netmq/issues/827), curve encryption has been added in 4.0.1.4, hope docs can be added for how to implement curves!