### PR TITLE
Fix "The Guide" links which are 404

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -83,7 +83,7 @@ url = "/community"
 title = "The Guide"
 description = "Explains how to use ØMQ with 60+ diagrams and 750 examples in 28 languages"
 icon = "fas fa-3x fa-book"
-url = "http://zguide.zeromq.org/page:all"
+url = "http://zguide.zeromq.org/"
 
 [[menu.navbar]]
 name = "Documentation"
@@ -97,7 +97,7 @@ weight = 2
 
 [[menu.navbar]]
 name = "The Guide"
-url = "http://zguide.zeromq.org/page:all"
+url = "http://zguide.zeromq.org/"
 weight = 3
 
 [[menu.navbar]]


### PR DESCRIPTION
It seems the addition of "page:all" at the end of these URLs causes 404 where if you remove that they work properly.

Maybe some mis-typed hugo magic?