### PR TITLE
docs: Readme and Python Examples updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ZeroMQ Website
 
-Website is using [hugo static website engine](https://gohugo.io/) and [netlify](https://www.netlify.com/) for hosting.
+Website is generated using [hugo](https://gohugo.io/), a static website engine
+and hosted via [netlify](https://www.netlify.com/).
 
 You can check it out at https://zeromq.org
 
@@ -8,11 +9,12 @@ You can check it out at https://zeromq.org
 
 ### Language Pages
 
-Help is needed with the different langauge pages https://github.com/zeromq/zeromq.org/tree/master/content/languages.
+Help is needed with the different language pages
+https://github.com/zeromq/zeromq.org/tree/master/content/languages.
 
 Please pick one of them and provide:
 
-1. Links to github, docs and package manager
+1. Links to `GitHub`, docs and package manager
 2. Download instructions
 3. Example
 
@@ -21,16 +23,16 @@ Please pick one of them and provide:
 Help is as well needed to translate the examples for different programming
 languages and libraries in the documentation.
 
-If you're translating from scratch you the hugo archetype which will create
-a stub for each example.
+If you're translating from scratch you the hugo archetype which will create a
+stub for each example.
 
 ```sh
 hugo new --kind examples docs/examples/<your language>/<your framework name>
 ```
 
-If you're like to add an example copy an exisiting on from
+If you're like to add an example copy an existing on from
 `content/docs/examples/c/libzmq/<example name>.md` to your language's and
-librarie's folder.
+library's folder.
 
 ## Run locally
 

--- a/content/docs/examples/python/pyzmq/hello_world_client.md
+++ b/content/docs/examples/python/pyzmq/hello_world_client.md
@@ -22,10 +22,10 @@ socket.connect("tcp://localhost:5555")
 
 #  Do 10 requests, waiting each time for a response
 for request in range(10):
-    print("Sending request %s …" % request)
+    print(f"Sending request {request} …")
     socket.send(b"Hello")
 
     #  Get the reply.
     message = socket.recv()
-    print("Received reply %s [ %s ]" % (request, message))
+    print(f"Received reply {request} [ {message} ]")
 ```

--- a/content/docs/examples/python/pyzmq/hello_world_server.md
+++ b/content/docs/examples/python/pyzmq/hello_world_server.md
@@ -21,7 +21,7 @@ socket.bind("tcp://*:5555")
 while True:
     #  Wait for next request from client
     message = socket.recv()
-    print("Received request: %s" % message)
+    print(f"Received request: {message}")
 
     #  Do some 'work'
     time.sleep(1)


### PR DESCRIPTION
## Changes

### README
  - fixed typos
  - word wrap
  - grammatical errors

### Python Examples
Use f-strings instead of the % operator, which shouldn't be encouraged in writing new code. Using the `.format` method would also work here since its addition in Python `3.x`, but f-strings have been supported since `3.6` and the default in all new distros is already `3.8` at this point. 
