### PR TITLE
Fix link to PyPi

### DIFF
--- a/content/languages/python.md
+++ b/content/languages/python.md
@@ -9,7 +9,7 @@ weight: 3
     <tr><td>Github</td><td><a href="https://github.com/zeromq/pyzmq">https://github.com/zeromq/pyzmq</a></td></tr>
 <tr><td>Docs</td><td><a href="https://zeromq.github.io/pyzmq/">https://zeromq.github.io/pyzmq/</a></td></tr>
 <tr><td>Guide</td><td><a href="http://zguide.zeromq.org/py:all">http://zguide.zeromq.org/py:all</a></td></tr>
-<tr><td>pypi</td><td<a href="https://pypi.org/project/pyzmq/">>https://pypi.org/project/pyzmq/</a></td></tr>
+<tr><td>pypi</td><td><a href="https://pypi.org/project/pyzmq/">https://pypi.org/project/pyzmq/</a></td></tr>
 </table>
 
 ### Download


### PR DESCRIPTION
There was a misplaced bracket causing the link to PyPi to be placed on top of the table rather than within it.