### PR TITLE
fix: jina.ai logo on website again.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -147,7 +147,7 @@ image = "https://upload.wikimedia.org/wikipedia/en/0/0b/Mongrel_2_logo.png"
 
 [[params.usedby]]
 name = "Jina"
-image = "https://docs.jina.ai/_static/logo-dark.svg"
+image = "https://docs.jina.ai/_static/logo-black.svg"
 
 [[params.links]]
 title = "The Guide"


### PR DESCRIPTION
Hi ZeroMQ team. earlier, I made a mistake because of the naming of the logos we have. This time, I've fixed that.