### PR TITLE
Send multipart of pairs instead of pairs of single parts.

### DIFF
--- a/content/docs/examples/cpp/cppzmq/pubsub_topics_pub.md
+++ b/content/docs/examples/cpp/cppzmq/pubsub_topics_pub.md
@@ -20,9 +20,10 @@ int main()
     zmq::socket_t publisher{context, zmq::socket_type::pub};
     publisher.bind("tcp://*:5555");
 
+    // Send a multipart messages forever
     while(true){
-        //  Write three messages, each with an envelope and content
-        publisher.send(zmq::str_buffer("status"), zmq::send_flags::none);
+        // Each consists of a topic envelope and content
+        publisher.send(zmq::str_buffer("status"), zmq::send_flags::sndmore);
         publisher.send(zmq::str_buffer("Message in status"));
     }
 


### PR DESCRIPTION
This makes the PUB consistent with its SUB and with the C examples