### PR TITLE
Change links to actually work

### DIFF
--- a/content/languages/csharp.md
+++ b/content/languages/csharp.md
@@ -10,9 +10,9 @@ NetMQ is the recommended option, which has implemented curve encryption (https:/
 ## NetMQ
 
 <table>
-<tr><td>Github</td><td>https://github.com/zeromq/netmq</td></tr>
-<tr><td>Docs</td><td>https://netmq.readthedocs.io/en/latest/</td></tr>
-<tr><td>Nuget</td><td>https://www.nuget.org/packages/NetMQ</td></tr>
+<tr><td>Github</td><td><a href="https://github.com/zeromq/netmq" target="_blank">https://github.com/zeromq/netmq</a></td></tr>
+    <tr><td>Docs</td><td><a href="https://netmq.readthedocs.io/en/latest/" target="_blank">https://netmq.readthedocs.io/en/latest/</a></td></tr>
+<tr><td>Nuget</td><td><a href="https://www.nuget.org/packages/NetMQ" target="_blank">https://www.nuget.org/packages/NetMQ</a></td></tr>
 </table>
 
 ### Request-Response
@@ -80,8 +80,8 @@ using (var publisher = new PublisherSocket())
 ## clrzmq4
 
 <table>
-<tr><td>Github</td><td>https://github.com/zeromq/clrzmq4</td></tr>
-<tr><td>Nuget</td><td>https://www.nuget.org/packages/ZeroMQ/</td></tr>
+    <tr><td>Github</td><td><a href="https://github.com/zeromq/clrzmq4" target="_blank">https://github.com/zeromq/clrzmq4</a></td></tr>
+<tr><td>Nuget</td><td><a href="https://www.nuget.org/packages/ZeroMQ/" target="_blank">https://www.nuget.org/packages/ZeroMQ/</a></td></tr>
 </table>
 
 Package include libzmq for Windows, for OSX and Linux you need to [install libzmq]({{< relref "/docs/download" >}}).


### PR DESCRIPTION
If you see https://zeromq.org/languages/csharp/, you'll notice that the links I've changed aren't actually anchor links. My change corrects that (and sets the target to _blank.