### PR TITLE
Migrate license page

### DIFF
--- a/content/docs/license.md
+++ b/content/docs/license.md
@@ -1,0 +1,27 @@
+---
+title: License
+description: License
+toc: true
+weight: 3
+---
+
+The [libzmq](https://github.com/zeromq/libzmq) library is licensed under the [https://www.mozilla.org/en-US/MPL/2.0/ Mozilla Public License 2.0].
+
+* **You get the full source code**. You can examine the code, modify it, and share your modified code under the terms of the MPL-2.0.
+
+* **Static linking is allowed**. The MPL-2.0 license give you permission to link this library with independent modules to produce an executable, regardless of the license terms of these independent modules, and to copy and distribute the resulting executable under terms of your choice, provided that you also meet, for each linked independent module, the terms and conditions of the license of that module. An independent module is a module which is not derived from or based on this library. If you modify this library, you must extend this exception to your version of the library. For more details on the terms of the MPL-2.0 license, check [https://www.mozilla.org/en-US/MPL/2.0/ its full text].
+
+## ZeroMQ for Commercial Applications
+
+* **ZeroMQ is safe for use in close-source applications**. The MPL-2.0 share-alike terms do not apply to applications built on top of ZeroMQ.
+
+* **You do not need a commercial license**. The MPL-2.0 applies to ZeroMQ's own source code, not your applications. Many commercial applications use ZeroMQ.
+
+## Old LGPLv3 + static link exception license
+
+libzmq used to be licensed under a custom LGPLv3 + static link exception license. The relicensing to MPL-2.0 has been completed with explicit permissions from all relevant copyright holders where necessary.
+
+## Licenses for Language Bindings
+
+Each language binding, whether it uses [libzmq](https://github.com/zeromq/libzmq) or not, comes with its own license.
+Please check the homepage of the language binding you intend to use for more details.

--- a/content/languages/c.md
+++ b/content/languages/c.md
@@ -83,7 +83,7 @@ int main (void)
 
 | Github | https://github.com/zeromq/libzmq |
 |--------|----------------------------------|
-| Docs   | https://libzmq.readthedocs.io//           |
+| Docs   | https://libzmq.readthedocs.io/   |
 
 
 ### Install

--- a/content/languages/cplusplus.md
+++ b/content/languages/cplusplus.md
@@ -28,17 +28,15 @@ int main()
 
 ## zmqpp
 
-<table>
-   <tr><td>Github</td><td><a href="https://github.com/zeromq/zmqpp">https://github.com/zeromq/zmqpp</a></td></tr>
-</table>
+| Github | https://github.com/zeromq/zmqpp |
+|--------|---------------------------------|
 
 This C++ binding for 0mq/zmq is a 'high-level' library that hides most of the c-style interface core 0mq provides. It consists of a number of header and source files all residing in the zmq directory, these files are provided under the MPLv2 license (see LICENSE for details).
 
 ## azmq
 
-<table>
-   <tr><td>Github</td><td><a href="https://github.com/zeromq/azmq">https://github.com/zeromq/azmq</a></td></tr>
-</table>
+| Github | https://github.com/zeromq/azmq |
+|--------|--------------------------------|
 
 The azmq library provides Boost Asio style bindings for ZeroMQ
 
@@ -72,8 +70,7 @@ int main(int argc, char** argv) {
 
 ## czmqpp
 
-<table>
-   <tr><td>Github</td><td><a href="https://github.com/zeromq/czmqpp">https://github.com/zeromq/czmqpp</a></td></tr>
-</table>
+| Github | https://github.com/zeromq/czmqpp |
+|--------|----------------------------------|
 
 C++ wrapper for czmq. Aims to be minimal, simple and consistent.

--- a/content/languages/csharp.md
+++ b/content/languages/csharp.md
@@ -79,10 +79,9 @@ using (var publisher = new PublisherSocket())
 
 ## clrzmq4
 
-<table>
-    <tr><td>Github</td><td><a href="https://github.com/zeromq/clrzmq4" target="_blank">https://github.com/zeromq/clrzmq4</a></td></tr>
-<tr><td>Nuget</td><td><a href="https://www.nuget.org/packages/ZeroMQ/" target="_blank">https://www.nuget.org/packages/ZeroMQ/</a></td></tr>
-</table>
+| Github | https://github.com/zeromq/clrzmq4       |
+|--------|-----------------------------------------|
+| Nuget  | https://www.nuget.org/packages/ZeroMQ/  |
 
 Package include libzmq for Windows, for OSX and Linux you need to [install libzmq]({{< relref "/docs/download" >}}).
 

--- a/content/languages/go.md
+++ b/content/languages/go.md
@@ -103,11 +103,10 @@ func main() {
 
 ## pebbe/zmq4
 
-<table>
-<tr><td>Github</td><td>https://github.com/pebbe/zmq4</td></tr>
-<tr><td>Docs</td><td>https://godoc.org/github.com/pebbe/zmq4</td></tr>
-<tr><td>Examples</td><td>https://github.com/pebbe/zmq4/tree/master/examples</td></tr>
-</table>
+| Github   | https://github.com/pebbe/zmq4              |
+|----------|--------------------------------------------|
+| Docs     | https://godoc.org/github.com/pebbe/zmq4    |
+| Examples | https://github.com/pebbe/zmq4/tree/master/examples |
 
 ### Installation
 


### PR DESCRIPTION
Problem: license page is only in old wiki website

Solution:
Migrate license page to new website.
Fix a few tables of link for language bindings.