### PR TITLE
Languages - rust. Fix crate installation and add alternative

### DIFF
--- a/content/languages/rust.md
+++ b/content/languages/rust.md
@@ -1,19 +1,46 @@
 ---
 title: Rust
-weight: 4
+weight: 3
+toc: true
 ---
+
+## Zmq - bindings for the libzmq
 
 | Github   | https://github.com/erickt/rust-zmq                      |
 |----------|---------------------------------------------------------|
 | Crate    | https://docs.rs/crate/zmq                               |
-| Examples | [https://github.com/erickt/rust-zmq/tree/master/examples](https://github.com/zeromq/zmq.rs/tree/master/examples) |
+| Examples | https://github.com/erickt/rust-zmq/tree/master/examples |
 
-## Installation
+### Installation
 
-Add the following Cargo.toml file:
-
-```toml
-[dependencies]
-zeromq = { version = "0.3.5", features = ["tcp-transport"] }
+#### Via cargo add:
+```bash
+cargo add zmq
 ```
 
+#### Via Cargo.toml file:
+```toml
+[dependencies]
+zmq = "0.10.5"
+```
+
+## Zeromq - rust native WIP
+**WARN**: not ready for production atm, check [README](https://github.com/zeromq/zmq.rs?tab=readme-ov-file#zmqrs---a-native-rust-implementation-of-zeromq)
+
+| Github   | https://github.com/zeromq/zmq.rs                        |
+|----------|---------------------------------------------------------|
+| Crate    | https://crates.io/crates/zeromq                         |
+| Examples | https://github.com/zeromq/zmq.rs/tree/master/examples   |
+
+### Installation
+
+#### Via cargo add:
+```bash
+cargo add zeromq
+```
+
+#### Via Cargo.toml file:
+```toml
+[dependencies]
+zeromq = "0.3.5"
+```


### PR DESCRIPTION
Crate installation example and crate links were inconsistent from last update - fixed. Added alternative crate from zeromq project itself