### PR TITLE
Fix up radio dish socket docs

### DIFF
--- a/content/docs/examples/cpp/cppzmq/raddsh_dish_example.md
+++ b/content/docs/examples/cpp/cppzmq/raddsh_dish_example.md
@@ -1,0 +1,34 @@
+---
+name: raddsh_dish_example
+language: cpp
+library: cppzmq
+---
+
+```cpp
+#include <cstdlib>
+#include <iostream>
+#include <zmq.hpp>
+
+int main() {
+  // Initialize the zmq context with a single IO thread
+  zmq::context_t context{1};
+
+  // Construct a Dish socket and connect to interface
+  zmq::socket_t dish{context, zmq::socket_type::dish};
+  dish.connect("tcp://localhost:5555");
+
+  // Join message groups
+  dish.join("group1");
+  dish.join("group2");
+
+  // Receive messages forever
+  while (true) {
+    std::cout << "Waiting to receive...\n";
+    zmq::message_t msg;
+    dish.recv(msg, zmq::recv_flags::none);
+    std::cout << "Received a message: " << msg.to_string() << "\n";
+  }
+
+  return EXIT_SUCCESS;
+}
+```

--- a/content/docs/examples/cpp/cppzmq/raddsh_radio_example.md
+++ b/content/docs/examples/cpp/cppzmq/raddsh_radio_example.md
@@ -1,0 +1,36 @@
+---
+name: raddsh_radio_example
+language: cpp
+library: cppzmq
+---
+
+```cpp
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <zmq.hpp>
+
+int main() {
+  // Initialize the zmq context with a single IO thread
+  zmq::context_t context{1};
+
+  // Construct a Radio socket and connect to interface.
+  zmq::socket_t radio{context, zmq::socket_type::radio};
+  radio.bind("tcp://*:5555");
+
+  // Send messages forever, alternating between 3 groups.
+  for (uint32_t i = 1; true; i = (i % 3 == 0) ? 1 : i + 1) {
+    std::string group = "group" + std::to_string(i);
+    std::string payload = "This is for " + group;
+    zmq::message_t msg{payload};
+    msg.set_group(group.c_str());
+    radio.send(msg, zmq::send_flags::none);
+    std::cout << "Sent a message to " << group << "\n";
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+
+  return EXIT_SUCCESS;
+}
+```

--- a/content/docs/socket_api.md
+++ b/content/docs/socket_api.md
@@ -532,15 +532,14 @@ single publisher to multiple subscribers in a fan out fashion.
 Radio-dish is using groups (vs Pub-sub topics), Dish sockets can join a group
 and each message sent by Radio sockets belong to a group.
 
-Groups are null terminated strings limited to 16 chars length (including null).
-The intention is to increase the length to 40 chars (including null). The
-encoding of groups shall be UTF8.
+Groups are null terminated strings limited to 255 bytes in length (including null).
+Each group character must be one byte with allowed values 1-255.
 
 Groups are matched using exact matching (vs prefix matching of PubSub).
 
 #### RADIO socket
 
-A RADIO socket is used by a publisher to distribute data. Each message belong to
+A RADIO socket is used by a publisher to distribute data. Each message belongs to
 a group. Messages are distributed to all members of a group. The *receive*
 operation is not implemented for this socket type.
 


### PR DESCRIPTION
I noticed that the [Socket API docs](https://zeromq.org/socket-api/#radio-dish-pattern) for Radio-Dish list the message group as limited to 16 bytes, whereas the [RFC](https://rfc.zeromq.org/spec/48/#group) and [implementation](https://github.com/zeromq/libzmq/blob/481cc3fa2c4414e407d863b4428f1efd5441e97d/include/zmq.h#L368) allow up to 255. While I was fixing that, I thought I'd throw in some radio-dish examples too.