### PR TITLE
Fix get started page

### DIFF
--- a/content/docs/get-started.md
+++ b/content/docs/get-started.md
@@ -53,31 +53,6 @@ port 5555 and then waits for messages. You can also see that we have zero
 configuration, we are just sending strings.
 
 {{< example hello_world_client >}}
-//  Hello World client
-#include <zmq.h>
-#include <string.h>
-#include <stdio.h>
-#include <unistd.h>
-
-int main (void)
-{
-    printf ("Connecting to hello world server…\n");
-    void *context = zmq_ctx_new ();
-    void *requester = zmq_socket (context, ZMQ_REQ);
-    zmq_connect (requester, "tcp://localhost:5555");
-
-    int request_nbr;
-    for (request_nbr = 0; request_nbr != 10; request_nbr++) {
-        char buffer [10];
-        printf ("Sending Hello %d…\n", request_nbr);
-        zmq_send (requester, "Hello", 5, 0);
-        zmq_recv (requester, buffer, 10, 0);
-        printf ("Received World %d\n", request_nbr);
-    }
-    zmq_close (requester);
-    zmq_ctx_destroy (context);
-    return 0;
-}
 
 The client creates a socket of type request, connects and starts sending
 messages.


### PR DESCRIPTION
This reverts commit 1b8914000b693d00b6f4b7e5a4982dded8fc5526.

The commit added an exact copy of the [libzmq example](https://github.com/zeromq/zeromq.org/blob/7e5c182a9f05177798a71687d4e15d3267ef85de/content/docs/examples/c/libzmq/hello_world_client.md) to the get started page, such that it is displayed for all languages with improper markup.

## Current state
![CleanShot 2024-06-25 at 11 22 48@2x](https://github.com/zeromq/zeromq.org/assets/14787415/11ab342a-2148-488f-a2b0-7938acd1e728)
