### PR TITLE
Correct language & library in Haskell Hello World example

### DIFF
--- a/content/docs/examples/haskell/zeromq4-haskell/hello_world_client.md
+++ b/content/docs/examples/haskell/zeromq4-haskell/hello_world_client.md
@@ -1,7 +1,7 @@
 ---
 name: hello_world_server
-language: python
-library: pyzmq
+language: haskell
+library: zeromq4-haskell
 ---
 
 ```haskell

--- a/content/docs/examples/haskell/zeromq4-haskell/hello_world_server.md
+++ b/content/docs/examples/haskell/zeromq4-haskell/hello_world_server.md
@@ -1,7 +1,7 @@
 ---
 name: hello_world_server
-language: python
-library: pyzmq
+language: haskell
+library: zeromq4-haskell
 ---
 
 ```haskell


### PR DESCRIPTION
In the Haskell Hello World example, language was wrongly written as Python in client & server markdown files. Corrected the language to Haskell and also corrected library name.