### PR TITLE
Corrected name of haskell lib - zeromq4-haskell

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -142,7 +142,7 @@ zmqLibraries:
 
     - name: Haskell
       libraries:
-        - name: zeromq-haskell
+        - name: zeromq4-haskell
           description: Haskell binding for libzmq
           language: Haskell
           gitUrl: https://gitlab.com/twittner/zeromq-haskell


### PR DESCRIPTION
Somewhat confusingly, the name of the [git repo](https://gitlab.com/twittner/zeromq-haskell) is "zeromq-haskell" but the actual Haskell package is called "zeromq4-haskell". Corrected name in site to "zeromq4-haskell".