### PR TITLE
Add Macos compatibility warning for dartzmq

### DIFF
--- a/content/languages/dart.md
+++ b/content/languages/dart.md
@@ -8,6 +8,9 @@ weight: 4
 | pub.dev  | https://pub.dev/packages/dartzmq                  |
 | Examples | https://github.com/enwi/dartzmq/tree/main/example |
 
+## ❗ Important ❗
+
+`dartzmq` does not currently work on Macos. See [issue here](https://github.com/enwi/dartzmq/issues/44)
 
 ## Installation
 


### PR DESCRIPTION
`dartzmq` does not work on Macos, noted in the documentation.

Just to save other devs time to attempt using this Flutter package.