### PR TITLE
Add OMQ implementations to Rust, Ruby, and Python pages

### DIFF
--- a/content/languages/python.md
+++ b/content/languages/python.md
@@ -1,7 +1,60 @@
 ---
 title: Python
 weight: 3
+toc: true
 ---
+
+## PyOMQ - drop-in pyzmq replacement, 2-3x faster
+
+Drop-in pyzmq replacement backed by omq.rs (pure Rust ZeroMQ). Same API, sync and asyncio, 2-3x throughput over TCP. No libzmq dependency.
+
+| Github | https://github.com/paddor/omq.rs/tree/main/bindings/pyomq |
+|--------|-----------------------------------------------------------|
+| PyPI   | https://pypi.org/project/pyomq/                           |
+
+### Download
+
+```bash
+pip install pyomq
+```
+
+### Example
+
+```python
+import pyomq
+
+ctx = pyomq.Context()
+
+push = ctx.socket(pyomq.PUSH)
+push.bind("tcp://127.0.0.1:5555")
+
+pull = ctx.socket(pyomq.PULL)
+pull.connect("tcp://127.0.0.1:5555")
+
+push.send(b"Hello World!")
+print(pull.recv())
+```
+
+asyncio:
+
+```python
+import asyncio
+import pyomq.asyncio
+
+async def main():
+    ctx = pyomq.asyncio.Context()
+
+    push = ctx.socket(pyomq.PUSH)
+    push.bind("tcp://127.0.0.1:5555")
+
+    pull = ctx.socket(pyomq.PULL)
+    pull.connect("tcp://127.0.0.1:5555")
+
+    await push.send(b"Hello World!")
+    print(await pull.recv())
+
+asyncio.run(main())
+```
 
 ## Pyzmq
 

--- a/content/languages/ruby.md
+++ b/content/languages/ruby.md
@@ -6,9 +6,9 @@ toc: true
 
 ## OMQ - pure Ruby, wire-compatible with libzmq
 
-Pure Ruby ZeroMQ implementation. No C extensions, no libzmq dependency. Faster than any binding in both throughput and latency. All standard socket types, TCP/IPC/inproc transports, CURVE/PLAIN mechanisms, lz4+tcp:// and zstd+tcp:// compression transports.
+Pure Ruby ZeroMQ implementation. No C extensions, no libzmq dependency. Faster than any binding in both throughput and latency. All standard and draft socket types, TCP/IPC/inproc transports, CURVE/PLAIN/BLAKE3ZMQ mechanisms, lz4+tcp:// and zstd+tcp:// compression transports.
 
-| Github | https://github.com/paddor/omq                |
+| Github | https://github.com/zeromq/omq.rb              |
 |--------|----------------------------------------------|
 | gem    | https://rubygems.org/gems/omq                |
 | CLI    | https://rubygems.org/gems/omq-cli            |

--- a/content/languages/ruby.md
+++ b/content/languages/ruby.md
@@ -8,7 +8,7 @@ toc: true
 
 Pure Ruby ZeroMQ implementation. No C extensions, no libzmq dependency. Faster than any binding in both throughput and latency. All standard and draft socket types, TCP/IPC/inproc transports, CURVE/PLAIN/BLAKE3ZMQ mechanisms, lz4+tcp:// and zstd+tcp:// compression transports.
 
-| Github | https://github.com/zeromq/omq                 |
+| Github | https://github.com/zeromq/omq.rb              |
 |--------|----------------------------------------------|
 | gem    | https://rubygems.org/gems/omq                |
 | CLI    | https://rubygems.org/gems/omq-cli            |

--- a/content/languages/ruby.md
+++ b/content/languages/ruby.md
@@ -1,7 +1,39 @@
 ---
 title: Ruby
 weight: 3
+toc: true
 ---
+
+## OMQ - pure Ruby, wire-compatible with libzmq
+
+Pure Ruby ZeroMQ implementation. No C extensions, no libzmq dependency. Faster than any binding in both throughput and latency. All standard socket types, TCP/IPC/inproc transports, CURVE/PLAIN mechanisms, lz4+tcp:// and zstd+tcp:// compression transports.
+
+| Github | https://github.com/paddor/omq                |
+|--------|----------------------------------------------|
+| gem    | https://rubygems.org/gems/omq                |
+| CLI    | https://rubygems.org/gems/omq-cli            |
+
+### Installation
+
+```bash
+gem install omq
+```
+
+### Example
+
+```ruby
+require "omq"
+
+push = OMQ.push
+push.connect("tcp://127.0.0.1:9000")
+push.send("Hello World!")
+
+pull = OMQ.pull
+pull.bind("tcp://127.0.0.1:9000")
+puts pull.recv
+```
+
+## rbzmq - bindings for the libzmq
 
 | Github | https://github.com/zeromq/rbzmq |
 |--------|---------------------------------|
@@ -9,7 +41,7 @@ weight: 3
 | Docs   | http://zeromq.github.io/rbzmq/  |
 
 
-## Installation
+### Installation
 
 [Install libzmq]({{< relref "/docs/download" >}}).
 
@@ -29,7 +61,7 @@ On Windows add a parameter for the libs. For example:
 gem install zmq -- --with-zmq-dir=c:/src/zeromq-4.3.2 --with-zmq-lib=c:/src/zeromq-4.3.2/src/.libs
 ```
 
-## Example
+### Example
 
 ```ruby
 require "zmq"

--- a/content/languages/ruby.md
+++ b/content/languages/ruby.md
@@ -8,7 +8,7 @@ toc: true
 
 Pure Ruby ZeroMQ implementation. No C extensions, no libzmq dependency. Faster than any binding in both throughput and latency. All standard and draft socket types, TCP/IPC/inproc transports, CURVE/PLAIN/BLAKE3ZMQ mechanisms, lz4+tcp:// and zstd+tcp:// compression transports.
 
-| Github | https://github.com/zeromq/omq.rb              |
+| Github | https://github.com/zeromq/omq                 |
 |--------|----------------------------------------------|
 | gem    | https://rubygems.org/gems/omq                |
 | CLI    | https://rubygems.org/gems/omq-cli            |

--- a/content/languages/rust.md
+++ b/content/languages/rust.md
@@ -4,6 +4,32 @@ weight: 3
 toc: true
 ---
 
+## OMQ - pure Rust, wire-compatible with libzmq
+
+Pure Rust ZeroMQ implementation. Two async backends (compio with io_uring, tokio), all socket types, compression transports (lz4+tcp://, zstd+tcp://), and CURVE/PLAIN/BLAKE3ZMQ mechanisms. Faster than libzmq at all message sizes.
+
+| Github   | https://github.com/paddor/omq.rs                        |
+|----------|---------------------------------------------------------|
+| Crate    | https://crates.io/crates/omq                            |
+
+Also provides:
+- [`omq-zeromq`](https://crates.io/crates/omq-zeromq): drop-in replacement for the `zeromq` crate
+- [`omq-zmq`](https://crates.io/crates/omq-zmq): libzmq-compatible C interface (`libomq_zmq.so`)
+- [`pyomq`](https://pypi.org/project/pyomq/): drop-in pyzmq replacement (2-3x faster)
+
+### Installation
+
+#### Via cargo add:
+```bash
+cargo add omq
+```
+
+#### Via Cargo.toml file:
+```toml
+[dependencies]
+omq = "0.5"
+```
+
 ## Zmq - bindings for the libzmq
 
 | Github   | https://github.com/erickt/rust-zmq                      |


### PR DESCRIPTION
## Summary

Adds three pure implementations of ZeroMQ to the language pages:

- **Rust:** [omq](https://github.com/paddor/omq.rs) — pure Rust, wire-compatible with libzmq, faster at all message sizes. Also lists omq-zeromq (zmq.rs drop-in), omq-zmq (C API), and pyomq.
- **Ruby:** [omq](https://github.com/paddor/omq) — pure Ruby, no C extensions, faster than any binding in throughput and latency.
- **Python:** [pyomq](https://pypi.org/project/pyomq/) — drop-in pyzmq replacement backed by omq.rs, 2-3x faster over TCP.

Existing entries (rust-zmq, zmq.rs, rbzmq, pyzmq) are preserved unchanged.